### PR TITLE
Test on Ruby 2.4.0 & Rails 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,3 @@ env:
   matrix:
     - RAILS_VERSION="~> 4.2"
     - RAILS_VERSION="~> 5.0.0"
-
-matrix:
-  exclude:
-    - rvm: 2.4.0
-      env: RAILS_VERSION="~> 4.2" # Rails 4.2 depends on json gem 1.8. However it couldn't be built with Ruby 2.4.


### PR DESCRIPTION
Now json gem 1.8.6 that works with Ruby 2.4.0 is released.